### PR TITLE
Get supportersCount for Project and ProjectReturn

### DIFF
--- a/app/controllers/api/v1/project_returns_controller.rb
+++ b/app/controllers/api/v1/project_returns_controller.rb
@@ -1,0 +1,9 @@
+class Api::V1::ProjectReturnsController < ApplicationController
+  def index
+    project = Project.find(params[:id]) 
+    project_returns = project.project_returns
+    render json: { 
+      projectReturns: project_returns.map { |project_return| ProjectReturnSerializer.new(project_return: project_return).as_json }
+    }
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,7 @@
 class Project < ApplicationRecord
   belongs_to :user
   has_many :project_returns
+  has_many :project_supports, through: :project_returns
 
   validates :title, presence: true
   validates :target_amount, presence: true

--- a/app/models/project_return.rb
+++ b/app/models/project_return.rb
@@ -1,3 +1,4 @@
 class ProjectReturn < ApplicationRecord
   belongs_to :project
+  has_many :project_supports
 end

--- a/app/serializers/project_return_serializer.rb
+++ b/app/serializers/project_return_serializer.rb
@@ -10,6 +10,7 @@ class ProjectReturnSerializer
       capacity: @project_return.capacity,
       deliveryDate: @project_return.delivery_date,
       description: @project_return.description,
+      supportersCount: @project_return.project_supports.count,
     }
   end
 end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -13,7 +13,6 @@ class ProjectSerializer
       user: {
         name: @project.user.name,
       },
-      projectReturns: @project.project_returns.map { |project_return| ProjectReturnSerializer.new(project_return: project_return).as_json },
     }
   end
 end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -10,6 +10,7 @@ class ProjectSerializer
       targetAmount: @project.target_amount,
       dueDate: @project.due_date,
       description: @project.description,
+      supportersCount: @project.project_supports.count,
       user: {
         name: @project.user.name,
       },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,11 @@ Rails.application.routes.draw do
           get :me
         end
       end
-      resources :projects, only: [:index, :show, :create]
+      resources :projects, only: [:index, :show, :create] do
+        member do
+          resources :project_returns, only: [:index]
+        end
+      end
       resources :project_supports, only: [:create]
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@ end
 
 unless Project.any?
   10.times do
-    Project.create!(
+    project = Project.create!(
       {
         user: User.first,
         title: '一月の火災で多くを失った、葉山一色海岸「UMIGOYA海小屋」の新たな出発を応援',
@@ -18,19 +18,16 @@ unless Project.any?
         description: '昨年、コロナ禍による海水浴場開設中止で大打撃を受け、さらに、年明け早々の火災で多くの資産を失うというダブルパンチを喰らった＜UMIGOYA海小屋＞。「どうか困難を乗り越えて、これまで以上に素敵な海の家として再スタートしてほしい！」　そんな応援の気持ちに賛同してくださる方を募っています。',
       }
     )
-  end
-end
-
-unless ProjectReturn.any?
-  10.times do |i|
-    ProjectReturn.create!(
-      {
-        project: Project.first,
-        price:  10000,
-        capacity: 100,
-        delivery_date: '2021-06-30',
-        description: '■『キャンプコット』Naturaldrop× 1個 （ブラック・ベージュ・レッド・グリーン・ブルー） ※ご希望のカラーをお選びください。 ※SNSシェアプレゼントをご希望のかたは、備考欄にSNSアカウント、投稿のURLをご記入ください。 ※製造状況により出荷時期が遅れる場合、早急にご連絡致します。',
-      }
-    )
+    3.times do |i|
+      ProjectReturn.create!(
+        {
+          project: project
+          price:  10000 * 3,
+          capacity: 100,
+          delivery_date: '2021-06-30',
+          description: '■『キャンプコット』Naturaldrop× 1個 （ブラック・ベージュ・レッド・グリーン・ブルー） ※ご希望のカラーをお選びください。 ※SNSシェアプレゼントをご希望のかたは、備考欄にSNSアカウント、投稿のURLをご記入ください。 ※製造状況により出荷時期が遅れる場合、早急にご連絡致します。',
+        }
+      )
+    end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,8 +21,8 @@ unless Project.any?
     3.times do |i|
       ProjectReturn.create!(
         {
-          project: project
-          price:  10000 * 3,
+          project: project,
+          price:  10000 * (i + 1),
           capacity: 100,
           delivery_date: '2021-06-30',
           description: '■『キャンプコット』Naturaldrop× 1個 （ブラック・ベージュ・レッド・グリーン・ブルー） ※ご希望のカラーをお選びください。 ※SNSシェアプレゼントをご希望のかたは、備考欄にSNSアカウント、投稿のURLをご記入ください。 ※製造状況により出荷時期が遅れる場合、早急にご連絡致します。',


### PR DESCRIPTION
## Objective
resolves: https://github.com/benrickken/crowdfunding-frontend/issues/35
* Display number of supporters for each ProjectReturn and Project as a total.
<!-- Describe the background and target of this PR -->

## What was changed
* Separated API for ProjectReturn
* Tweaked seeds.rb
* Added supportersCount to ProjectReturnSerializer
* Added supportersCount to ProjectSerializer
<!-- Explain in detail what was changed in this PR -->

## Related Links
https://github.com/benrickken/crowdfunding-frontend/pull/34
<!-- Add related links -->
