### PR TITLE
プロジェクトの目標金額到達時のステータス更新

### DIFF
--- a/app/controllers/api/v1/project_supports_controller.rb
+++ b/app/controllers/api/v1/project_supports_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::ProjectSupportsController < ApplicationController
     ActiveRecord::Base.transaction do
       project_support.save!
       project = project_support.project_return.project
-      project.update!(complete_flag: true) if project.supported_amount >= project.target_amount
+      project.completed! if project.supported_amount >= project.target_amount
     end
 
     render json: { project_support: project_support }

--- a/app/controllers/api/v1/project_supports_controller.rb
+++ b/app/controllers/api/v1/project_supports_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::ProjectSupportsController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    project_support = ProjectSupport.create_and_update_project_progress!(user: current_user, params: project_support_params)
+    project_support = ProjectSupport.create_with_complete_check!(user: current_user, params: project_support_params)
 
     render json: { project_support: project_support }
   end

--- a/app/controllers/api/v1/project_supports_controller.rb
+++ b/app/controllers/api/v1/project_supports_controller.rb
@@ -5,8 +5,6 @@ class Api::V1::ProjectSupportsController < ApplicationController
     project_support = ProjectSupport.create_and_update_project_progress!(user: current_user, params: project_support_params)
 
     render json: { project_support: project_support }
-  rescue StandardError => e
-    render json: e, status: :unprocessable_entity
   end
 
   private

--- a/app/controllers/api/v1/project_supports_controller.rb
+++ b/app/controllers/api/v1/project_supports_controller.rb
@@ -2,13 +2,7 @@ class Api::V1::ProjectSupportsController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    project_support = current_user.project_supports.new(project_support_params)
-
-    ActiveRecord::Base.transaction do
-      project_support.save!
-      project = project_support.project_return.project
-      project.completed! if project.supported_amount >= project.target_amount
-    end
+    project_support = ProjectSupport.create_and_update_project_progress!(user: current_user, params: project_support_params)
 
     render json: { project_support: project_support }
   rescue StandardError => e

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -13,7 +13,9 @@ class Project < ApplicationRecord
   validates :title, presence: true
   validates :target_amount, presence: true
   validates :due_date, presence: true
-  validates :complete_flag, inclusion: { in: [true, false] }
+  validates :progress, presence: true
+
+  enum progress: %i[incomplete completed]
 
   def image_url
     image.attached? ? url_for(image) : nil

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -13,6 +13,7 @@ class Project < ApplicationRecord
   validates :title, presence: true
   validates :target_amount, presence: true
   validates :due_date, presence: true
+  validates :complete_flag, inclusion: { in: [true, false] }
 
   def image_url
     image.attached? ? url_for(image) : nil

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -30,4 +30,8 @@ class Project < ApplicationRecord
   def created_by?(user)
     user_id == user&.id
   end
+
+  def update_if_complete!
+    completed! if supported_amount >= target_amount
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,7 +15,7 @@ class Project < ApplicationRecord
   validates :due_date, presence: true
   validates :progress, presence: true
 
-  enum progress: %i[incomplete completed]
+  enum progress: { incomplete: 0, completed: 1 }
 
   def image_url
     image.attached? ? url_for(image) : nil

--- a/app/models/project_support.rb
+++ b/app/models/project_support.rb
@@ -11,7 +11,7 @@ class ProjectSupport < ApplicationRecord
     ActiveRecord::Base.transaction do
       project_support.save!
       project = project_support.project_return.project
-      project.completed! if project.supported_amount >= project.target_amount
+      project.update_if_complete!
     end
 
     project_support

--- a/app/models/project_support.rb
+++ b/app/models/project_support.rb
@@ -4,4 +4,16 @@ class ProjectSupport < ApplicationRecord
 
   validates :project_return_id, presence: true, uniqueness: { scope: :user_id }
   validates :user_id, presence: true
+
+  def self.create_and_update_project_progress!(user:, params:)
+    project_support = user.project_supports.new(params)
+
+    ActiveRecord::Base.transaction do
+      project_support.save!
+      project = project_support.project_return.project
+      project.completed! if project.supported_amount >= project.target_amount
+    end
+
+    project_support
+  end
 end

--- a/app/models/project_support.rb
+++ b/app/models/project_support.rb
@@ -5,7 +5,7 @@ class ProjectSupport < ApplicationRecord
   validates :project_return_id, presence: true, uniqueness: { scope: :user_id }
   validates :user_id, presence: true
 
-  def self.create_and_update_project_progress!(user:, params:)
+  def self.create_with_complete_check!(user:, params:)
     project_support = user.project_supports.new(params)
 
     ActiveRecord::Base.transaction do

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -10,7 +10,7 @@ class ProjectSerializer
       targetAmount: @project.target_amount,
       dueDate: @project.due_date,
       description: @project.description,
-      completeFlag: @project.complete_flag,
+      progress: @project.progress,
       supportersCount: @project.project_supports.count,
       supportedAmount: @project.supported_amount,
       imageUrl: @project.image_url,

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -10,6 +10,7 @@ class ProjectSerializer
       targetAmount: @project.target_amount,
       dueDate: @project.due_date,
       description: @project.description,
+      completeFlag: @project.complete_flag,
       supportersCount: @project.project_supports.count,
       supportedAmount: @project.supported_amount,
       imageUrl: @project.image_url,

--- a/db/migrate/20210529030033_add_complete_flag_to_projects.rb
+++ b/db/migrate/20210529030033_add_complete_flag_to_projects.rb
@@ -1,5 +1,0 @@
-class AddCompleteFlagToProjects < ActiveRecord::Migration[6.1]
-  def change
-    add_column :projects, :complete_flag, :boolean, default: false
-  end
-end

--- a/db/migrate/20210529030033_add_complete_flag_to_projects.rb
+++ b/db/migrate/20210529030033_add_complete_flag_to_projects.rb
@@ -1,0 +1,5 @@
+class AddCompleteFlagToProjects < ActiveRecord::Migration[6.1]
+  def change
+    add_column :projects, :complete_flag, :boolean, default: false
+  end
+end

--- a/db/migrate/20210529030033_add_progress_to_projects.rb
+++ b/db/migrate/20210529030033_add_progress_to_projects.rb
@@ -1,0 +1,5 @@
+class AddProgressToProjects < ActiveRecord::Migration[6.1]
+  def change
+    add_column :projects, :progress, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -69,7 +69,7 @@ ActiveRecord::Schema.define(version: 2021_05_29_030033) do
     t.text "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "complete_flag", default: false
+    t.integer "progress", default: 0
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_18_132234) do
+ActiveRecord::Schema.define(version: 2021_05_29_030033) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 2021_05_18_132234) do
     t.text "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "complete_flag", default: false
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     title { '一月の火災で多くを失った、葉山一色海岸「UMIGOYA海小屋」の新たな出発を応援' }
     target_amount { 7_000_000 }
     due_date { '2022-01-01' }
+    complete_flag { false }
   end
 end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
     title { '一月の火災で多くを失った、葉山一色海岸「UMIGOYA海小屋」の新たな出発を応援' }
     target_amount { 7_000_000 }
     due_date { '2022-01-01' }
-    complete_flag { false }
+    progress { :incomplete }
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe Project, type: :model do
     it 'is invalid without due_date' do
       expect(build(:project, due_date: nil)).to be_invalid
     end
+
+    it 'is invalid without complete_flag' do
+      expect(build(:project, complete_flag: nil)).to be_invalid
+    end
   end
 
   describe 'instance methods' do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -82,5 +82,28 @@ RSpec.describe Project, type: :model do
         it { is_expected.to eq(true) }
       end
     end
+
+    describe '#update_if_complete!' do
+      let(:project) { create(:project, target_amount: 10_000, progress: 'incomplete') }
+      subject { project.update_if_complete! }
+
+      context 'when supported_amount reaches target_amount' do
+        before do
+          project_return = create(:project_return, project: project, price: 10_000)
+          create(:project_support, project_return: project_return)
+        end
+
+        it 'changes project progress to completed' do
+          subject
+          expect(project.progress).to eq 'completed'
+        end
+      end
+
+      context 'when supported_amount has not reached target_amount' do
+        it 'keeps project progress incomplete' do
+          expect(project.progress).to eq 'incomplete'
+        end
+      end
+    end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -94,8 +94,7 @@ RSpec.describe Project, type: :model do
         end
 
         it 'changes project progress to completed' do
-          subject
-          expect(project.progress).to eq 'completed'
+          expect { subject }.to change(project, :progress).to('completed')
         end
       end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Project, type: :model do
 
       context 'when supported_amount has not reached target_amount' do
         it 'keeps project progress incomplete' do
-          expect(project.progress).to eq 'incomplete'
+          expect { subject }.not_to change(project, :progress)
         end
       end
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Project, type: :model do
       expect(build(:project, due_date: nil)).to be_invalid
     end
 
-    it 'is invalid without complete_flag' do
-      expect(build(:project, complete_flag: nil)).to be_invalid
+    it 'is invalid without progress' do
+      expect(build(:project, progress: nil)).to be_invalid
     end
   end
 

--- a/spec/models/project_support_spec.rb
+++ b/spec/models/project_support_spec.rb
@@ -24,4 +24,17 @@ RSpec.describe ProjectSupport, type: :model do
       expect(build(:project_support, user_id: nil)).to be_invalid
     end
   end
+
+  describe 'class methods' do
+    describe '.create_with_complete_check!' do
+      let(:user) { create(:user) }
+      let(:project_return) { create(:project_return) }
+      let(:params) { { project_return_id: project_return.id } }
+      subject { ProjectSupport.create_with_complete_check!(user: user, params: params) }
+
+      it 'creates project_support' do
+        expect { subject }.to change(ProjectSupport, :count).by(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Objective
resolves: https://github.com/benrickken/crowdfunding-frontend/issues/59
<!-- Describe the background and target of this PR -->

## What was changed
* Projectにcomplete_flagを追加しました
* Transactionを用いて、ProjectSupportが作られたときにtarget_amountとsupported_amountを比較して、超えてたらProjectのcompleteを更新
* completeFlagをAPIで返すようにSerializerに追加
<!-- Explain in detail what was changed in this PR -->