### PR TITLE
Add completed_at to Project

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -30,6 +30,6 @@ class Project < ApplicationRecord
   end
 
   def update_if_complete!
-    completed! if supported_amount >= target_amount
+    update!(progress: :completed, completed_at: Time.zone.now) if supported_amount >= target_amount
   end
 end

--- a/db/migrate/20210613123256_add_completed_at_to_projects.rb
+++ b/db/migrate/20210613123256_add_completed_at_to_projects.rb
@@ -1,0 +1,5 @@
+class AddCompletedAtToProjects < ActiveRecord::Migration[6.1]
+  def change
+    add_column :projects, :completed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_29_030033) do
+ActiveRecord::Schema.define(version: 2021_06_13_123256) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 2021_05_29_030033) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "progress", default: 0
+    t.datetime "completed_at"
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -98,7 +98,8 @@ RSpec.describe Project, type: :model do
         end
 
         it 'changes project completed_at to current time' do
-          expect { subject }.to change(project, :completed_at).to be_within(1.second).of(Time.zone.now)
+          subject
+          expect(project.completed_at).not_to be_nil
         end
       end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -96,6 +96,10 @@ RSpec.describe Project, type: :model do
         it 'changes project progress to completed' do
           expect { subject }.to change(project, :progress).to('completed')
         end
+
+        it 'changes project completed_at to current time' do
+          expect { subject }.to change(project, :completed_at).to be_within(1.second).of(Time.zone.now)
+        end
       end
 
       context 'when supported_amount has not reached target_amount' do


### PR DESCRIPTION
## Objective
https://github.com/benrickken/crowdfunding-frontend/issues/63 の集計のためにProjectにcompleted_atを追加しました。
progressと用途が若干被りそうなのですが、progressは今後incomplete, completed以外の要素も増えうるので一旦このまま両方維持しています。
<!-- Describe the background and target of this PR -->