### PR TITLE
Add email to users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'rubocop', require: false
   gem 'rspec-rails', '~> 5.0.0'
+  gem 'faker'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,8 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faker (2.18.0)
+      i18n (>= 1.6, < 2)
     ffi (1.15.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -235,6 +237,7 @@ DEPENDENCIES
   byebug
   dotenv-rails
   factory_bot_rails
+  faker
   jwt
   listen (~> 3.3)
   mysql2 (~> 0.5)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -15,6 +15,6 @@ class Api::V1::UsersController < Api::V1::BaseController
   private
 
   def user_params
-    params.require(:user).permit(:name)
+    params.require(:user).permit(:name, :email)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,5 +5,6 @@ class User < ApplicationRecord
   has_many :backed_projects, through: :project_returns, source: :project
 
   validates :uid, presence: true, uniqueness: true
+  validates :email, presence: true, uniqueness: true
   validates :name, presence: true
 end

--- a/db/migrate/20210613125018_add_email_to_users.rb
+++ b/db/migrate/20210613125018_add_email_to_users.rb
@@ -1,0 +1,5 @@
+class AddEmailToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :email, :string, null: false, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_13_123256) do
+ActiveRecord::Schema.define(version: 2021_06_13_125018) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 2021_06_13_123256) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "name"
+    t.string "email", null: false
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,8 +2,9 @@ unless User.any?
   User.create!(
     {
       uid: SecureRandom.uuid,
-      name: 'John',
-    },
+      email: Faker::Internet.email,
+      name: Faker::Name.name
+    }
   )
 end
 
@@ -13,19 +14,19 @@ unless Project.any?
       {
         user: User.first,
         title: '一月の火災で多くを失った、葉山一色海岸「UMIGOYA海小屋」の新たな出発を応援',
-        target_amount: 7000000,
+        target_amount: 7_000_000,
         due_date: '2021-04-28',
-        description: '昨年、コロナ禍による海水浴場開設中止で大打撃を受け、さらに、年明け早々の火災で多くの資産を失うというダブルパンチを喰らった＜UMIGOYA海小屋＞。「どうか困難を乗り越えて、これまで以上に素敵な海の家として再スタートしてほしい！」　そんな応援の気持ちに賛同してくださる方を募っています。',
+        description: '昨年、コロナ禍による海水浴場開設中止で大打撃を受け、さらに、年明け早々の火災で多くの資産を失うというダブルパンチを喰らった＜UMIGOYA海小屋＞。「どうか困難を乗り越えて、これまで以上に素敵な海の家として再スタートしてほしい！」　そんな応援の気持ちに賛同してくださる方を募っています。'
       }
     )
     3.times do |i|
       ProjectReturn.create!(
         {
           project: project,
-          price:  10000 * (i + 1),
+          price: 10_000 * (i + 1),
           capacity: 100,
           delivery_date: '2021-06-30',
-          description: '■『キャンプコット』Naturaldrop× 1個 （ブラック・ベージュ・レッド・グリーン・ブルー） ※ご希望のカラーをお選びください。 ※SNSシェアプレゼントをご希望のかたは、備考欄にSNSアカウント、投稿のURLをご記入ください。 ※製造状況により出荷時期が遅れる場合、早急にご連絡致します。',
+          description: '■『キャンプコット』Naturaldrop× 1個 （ブラック・ベージュ・レッド・グリーン・ブルー） ※ご希望のカラーをお選びください。 ※SNSシェアプレゼントをご希望のかたは、備考欄にSNSアカウント、投稿のURLをご記入ください。 ※製造状況により出荷時期が遅れる場合、早急にご連絡致します。'
         }
       )
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :user do
     uid { SecureRandom.uuid }
-    name { 'Ben Rickken' }
+    email { Faker::Internet.email }
+    name { Faker::Name.name }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe User, type: :model do
       expect(build(:user, uid: user.uid)).to be_invalid
     end
 
+    it 'is invalid without email' do
+      expect(build(:user, email: nil)).to be_invalid
+    end
+
+    it 'is invalid without unique email' do
+      expect(build(:user, email: user.email)).to be_invalid
+    end
+
     it 'is invalid without name' do
       expect(build(:user, name: nil)).to be_invalid
     end


### PR DESCRIPTION
## Objective
https://github.com/benrickken/crowdfunding-frontend/issues/63 のメールを送信する上で、Rails API側にメールアドレスがなく、毎回Firebaseに取りに行くのは大変そうなので保存するようにしました。
<!-- Describe the background and target of this PR -->

## Related Links
https://github.com/benrickken/crowdfunding-frontend/pull/66
<!-- Add related links -->
