### PR TITLE
Add link to notification

### DIFF
--- a/app/controllers/api/v1/mes_controller.rb
+++ b/app/controllers/api/v1/mes_controller.rb
@@ -6,8 +6,9 @@ class Api::V1::MesController < Api::V1::BaseController
   end
 
   def notifications
+    notifications = current_user.notifications.order(created_at: :desc)
     render json: {
-      notifications: current_user.notifications.map { |notification| NotificationSerializer.new(notification: notification).as_json }
+      notifications: notifications.map { |notification| NotificationSerializer.new(notification: notification).as_json }
     }
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -12,7 +12,12 @@ class Comment < ApplicationRecord
 
     ActiveRecord::Base.transaction do
       comment.save!
-      Notification.create!(user: project.user, body: "「#{project.title}」に新しいコメントが届いています。", status: :unread)
+      Notification.create!(
+        user: project.user,
+        body: "「#{project.title}」に新しいコメントが届いています。",
+        status: :unread,
+        link: "/projects/#{project.id}"
+      )
       comment
     end
   end

--- a/app/serializers/notification_serializer.rb
+++ b/app/serializers/notification_serializer.rb
@@ -8,6 +8,7 @@ class NotificationSerializer
       id: @notification.id,
       body: @notification.body,
       status: @notification.status,
+      link: @notification.link,
       createdAt: @notification.created_at
     }
   end

--- a/db/migrate/20210620063921_add_link_to_notification.rb
+++ b/db/migrate/20210620063921_add_link_to_notification.rb
@@ -1,0 +1,5 @@
+class AddLinkToNotification < ActiveRecord::Migration[6.1]
+  def change
+    add_column :notifications, :link, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_16_230844) do
+ActiveRecord::Schema.define(version: 2021_06_20_063921) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2021_06_16_230844) do
     t.integer "status", default: 0
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "link"
     t.index ["user_id"], name: "index_notifications_on_user_id"
   end
 

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     user
     body { 'My Notification' }
     status { :unread }
+    link { '/projects/1' }
   end
 end


### PR DESCRIPTION
## Objective
Notificationにlinkを追加できるようにしました。
<!-- Describe the background and target of this PR -->

## What was changed
* Notificationにlinkを追加
  * factoriesの追加
* Notification作成時にlinkも作られるように
* serializerに追加
* Notificationの順序をcreated_at: :descに変更
<!-- Explain in detail what was changed in this PR -->

## Related Links
https://github.com/benrickken/crowdfunding-frontend/pull/71/commits/555634c65f785b404d72ef1ed1a878b5bd453954
<!-- Add related links -->
